### PR TITLE
Fontpreloader

### DIFF
--- a/source/sass/_bootstrap-variables.scss
+++ b/source/sass/_bootstrap-variables.scss
@@ -62,7 +62,7 @@ $header-underline-color: darken($body-bg, 10%);
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif:  'Open Sans', Verdana, Helvetica, Arial, sans-serif;
+$font-family-sans-serif:  Verdana, Helvetica, Arial, sans-serif;
 $font-family-serif: Georgia, "Times New Roman", Times, serif;
 
 //* Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.

--- a/source/sass/bootstrap/_normalize.scss
+++ b/source/sass/bootstrap/_normalize.scss
@@ -80,11 +80,6 @@ a:hover {
 // Text-level semantics
 // ==========================================================================
 
-//
-
-//
-// Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
-//
 
 
 // Embedded content
@@ -105,18 +100,6 @@ img {
 svg:not(:root) {
   overflow: hidden;
 }
-
-// Grouping content
-// ==========================================================================
-
-//
-// Address margin not present in IE 8/9 and Safari.
-//
-
-figure {
-  margin: 1em 40px;
-}
-
 
 
 
@@ -218,11 +201,11 @@ input {
 // 2. Remove excess padding in IE 8/9/10.
 //
 
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box; // 1
-  padding: 0; // 2
-}
+// input[type="checkbox"],
+// input[type="radio"] {
+//   box-sizing: border-box; // 1
+//   padding: 0; // 2
+// }
 
 //
 // Fix the cursor style for Chrome's increment/decrement buttons. For certain
@@ -286,12 +269,12 @@ fieldset {
 // Remove most spacing between table cells.
 //
 
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
+// table {
+//   border-collapse: collapse;
+//   border-spacing: 0;
+// }
 
-td,
-th {
-  padding: 0;
-}
+// td,
+// th {
+//   padding: 0;
+// }

--- a/source/sass/bootstrap/_scaffolding.scss
+++ b/source/sass/bootstrap/_scaffolding.scss
@@ -66,9 +66,9 @@ a {
 // We reset this here because previously Normalize had no `figure` margins. This
 // ensures we don't break anyone's use of the element.
 
-figure {
-  margin: 0;
-}
+// figure {
+//   margin: 0;
+// }
 
 
 // Images
@@ -83,29 +83,29 @@ img {
 }
 
 // Rounded corners
-.img-rounded {
-  border-radius: $border-radius-large;
-}
+// .img-rounded {
+//   border-radius: $border-radius-large;
+// }
 
 // Image thumbnails
 //
 // Heads up! This is mixin-ed into thumbnails.less for `.thumbnail`.
-.img-thumbnail {
-  padding: $thumbnail-padding;
-  line-height: $line-height-base;
-  background-color: $thumbnail-bg;
-  border: 1px solid $thumbnail-border;
-  border-radius: $thumbnail-border-radius;
-  @include transition(all .2s ease-in-out);
+// .img-thumbnail {
+//   padding: $thumbnail-padding;
+//   line-height: $line-height-base;
+//   background-color: $thumbnail-bg;
+//   border: 1px solid $thumbnail-border;
+//   border-radius: $thumbnail-border-radius;
+//   @include transition(all .2s ease-in-out);
 
-  // Keep them at most 100% wide
-  @include img-responsive(inline-block);
-}
+//   // Keep them at most 100% wide
+//   @include img-responsive(inline-block);
+// }
 
 // Perfect circle
-.img-circle {
-  border-radius: 50%; // set radius in percents
-}
+// .img-circle {
+//   border-radius: 50%; // set radius in percents
+// }
 
 
 // Horizontal rules

--- a/source/sass/partials/_googleFonts.scss
+++ b/source/sass/partials/_googleFonts.scss
@@ -1,0 +1,12 @@
+.wf-active body {
+  font-family: "Open Sans", $font-family-base;
+}
+
+.wf-opensans-n4-inactive body {
+  font-family: $font-family-base;
+  background-color: blue;
+}
+
+.wf-loading body {
+  font-family: "Open Sans", $font-family-base;
+}

--- a/source/sass/style.scss
+++ b/source/sass/style.scss
@@ -3,6 +3,7 @@
 // Core variables and mixins
 @import "bootstrap/variables";
 @import "bootstrap-variables";
+@import "partials/googleFonts";
 @import "bootstrap/mixins";
 
 // Reset and dependencies

--- a/source/views/head.mustache
+++ b/source/views/head.mustache
@@ -4,7 +4,15 @@
 <!--[if lte IE 9]>
   <script>window.location.replace("{{appUrl}}/upgrade/");</script>
 <![endif]-->
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,600' rel='stylesheet' type='text/css'>
 <link rel="shortcut icon" href="{{appUrl}}/images/favicon.ico" />
 {{{css}}}
 <script src="http://yui.yahooapis.com/3.18.1/build/yui/yui-min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.10/webfont.js"></script>
+<script>
+WebFont.load({
+    google: {
+      families: ['Open Sans:300,400,600']
+    },
+    timeout: 3000
+});
+</script>


### PR DESCRIPTION
This is a way to timeout loading a font - currently set to 3 seconds - after which time a system font is used.  
The idea is to improve mobile experience (on slow connection) and also deal with outlier cases when the font fails to load at all for whatever reason. 